### PR TITLE
BugFix regarding vocabularies and the tags feature of select2.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix recarding vocabularies and the tags feature of select2.
+  [mathias.leimgruber]
 
 
 1.1.0 (2017-02-08)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -80,6 +80,22 @@ class KeywordWidget(SelectWidget):
                 new_values.add(cleanedup_value)
         return list(new_values)
 
+    def cleanup_request(self):
+        """
+        If the tags feature is enabled the new term is also in a
+        "not normalized" variation in the request. We need to remove it, thus
+        the super call of the sequence widget will still work.
+        Otherwise it does not recognize all terms in the request as valid term.
+        """
+        values = self.request.get(self.name, [])
+        if not values:
+            return
+
+        for new_value in self.get_new_values_from_request():
+            if new_value in values:
+                values.remove(new_value)
+        self.request.set(self.name, values)
+
     def update(self):
         super(KeywordWidget, self).update()
 
@@ -102,7 +118,7 @@ class KeywordWidget(SelectWidget):
                 'label_no_result': translate(self.promptNoresultFound,
                                              context=self.request),
                 'label_new': translate(self.labelNew,
-                                             context=self.request)
+                                       context=self.request)
             },
             'width': '300px',
             'allowClear': not self.field.required and not self.multiple,
@@ -144,6 +160,9 @@ class KeywordWidget(SelectWidget):
     def extract(self, default=NOVALUE):
         """See z3c.form.interfaces.IWidget.
         """
+
+        self.cleanup_request()
+
         values = super(KeywordWidget, self).extract(default=default)
 
         if not self.show_add_term_field():


### PR DESCRIPTION
The makes sure that all terms from the request are in the vocabulary.
This works well until you enter a term containing umlauts. 

The request contains a Unicode string an the vocabulary 7bit ascii string. 
The fallback results in a empty vocabulary, since the term in the request containing a umlaut is not in the vocabulary (only the 7bit ascii representation).