### PR TITLE
Fix selec2js profile path to select2 resources.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 - Fix an issue if the user only inserts one keyword into the widget.
   [elioschmutz]
 
+- Fix selec2js profile path to select2 resources. [deiferni]
+
 
 1.1.2 (2017-03-02)
 ------------------

--- a/ftw/keywordwidget/profiles/select2js/cssregistry.xml
+++ b/ftw/keywordwidget/profiles/select2js/cssregistry.xml
@@ -2,7 +2,7 @@
 <object name="portal_css">
 
   <stylesheet
-      id="++resource++ftw.keywordwidget/select2-4.0.3/dist/css/select2.min.css"
+      id="++resource++ftw.keywordwidget/select2/dist/css/select2.min.css"
       title=""
       cacheable="True"
       compression="none"

--- a/ftw/keywordwidget/profiles/select2js/jsregistry.xml
+++ b/ftw/keywordwidget/profiles/select2js/jsregistry.xml
@@ -2,7 +2,7 @@
 <object name="portal_javascripts">
 
     <javascript
-        id="++resource++ftw.keywordwidget/select2-4.0.3/dist/js/select2.min.js"
+        id="++resource++ftw.keywordwidget/select2/dist/js/select2.min.js"
         enabled="True"
         insert-after="++resource++plone.app.jquery.js"
         authenticated="True"


### PR DESCRIPTION
The folder was renamed, but this was not updated in the profile's configuration.

Fix for the changes introduced in https://github.com/4teamwork/ftw.keywordwidget/pull/5.