### PR TITLE
Don't drop user-input when a form including the widget has validation errors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- Don't drop user-input when a form including the widget has validation errors. [deiferni]
+
 - Fix an issue if the user only inserts one keyword into the widget.
   [elioschmutz]
 

--- a/ftw/keywordwidget/testing.py
+++ b/ftw/keywordwidget/testing.py
@@ -23,6 +23,11 @@ class FtwLayer(PloneSandboxLayer):
 
         z2.installProduct(app, 'ftw.keywordwidget')
 
+        import ftw.keywordwidget.tests
+        xmlconfig.file('tests.zcml',
+                       ftw.keywordwidget.tests,
+                       context=configurationContext)
+
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.keywordwidget:default')
 

--- a/ftw/keywordwidget/tests/behavior.py
+++ b/ftw/keywordwidget/tests/behavior.py
@@ -1,0 +1,10 @@
+from plone.supermodel import model
+from zope import schema
+
+
+class IHaveARequiredTextField(model.Schema):
+
+    fillme = schema.Text(
+        title=u'Fill me',
+        required=True,
+    )

--- a/ftw/keywordwidget/tests/tests.zcml
+++ b/ftw/keywordwidget/tests/tests.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="ftw.keywordwidget.tests">
+
+  <plone:behavior
+      title="Test-behavior that includes required fiels."
+      provides=".behavior.IHaveARequiredTextField"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
+</configure>

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -102,10 +102,11 @@ class KeywordWidget(SelectWidget):
         self.request.set(self.name, values)
 
     def update(self):
+        self.get_choice_field()
+
         super(KeywordWidget, self).update()
 
         self.update_multivalued_property()
-        self.get_choice_field()
         self.update_js_config()
 
         if isinstance(self.choice_field, ChoicePlus):
@@ -165,7 +166,6 @@ class KeywordWidget(SelectWidget):
     def extract(self, default=NOVALUE):
         """See z3c.form.interfaces.IWidget.
         """
-
         self.cleanup_request()
 
         values = super(KeywordWidget, self).extract(default=default)


### PR DESCRIPTION
Currently when the widget is rendered with `select2js` it will drop user input in the add-form when other fields have validation errors. This PR fixes that issue by always marking user input as a `selected` option in the select field when rendering the form after it has been submitted once.

At the moment the choice field is initialized too late during the forms `update`. It won't be set during
the first call to `extract` which happens during super's update and should set the submitted value on the widget. Thus the value won't be saved on the widget correctly and won't be rendered as selected. This PR moves the choice-field initialization before the super call to make
sure that the choice_field is already available in the first call to `extract`.

The second call to `extract` will then happen in a form's `extractData` and correclty return the new value.

Fixes https://github.com/4teamwork/opengever.core/issues/2657.