### PR TITLE
Fix keywords with non-ascii character being duplicated after validation error

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- No longer duplicate keywords with non ascii chars. [deiferni]
+
 - Don't drop user-input when a form including the widget has validation errors. [deiferni]
 
 - Fix an issue if the user only inserts one keyword into the widget.

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -199,10 +199,7 @@ class KeywordWidget(SelectWidget):
             for new_value in new_values:
                 # The new values needs to fit the token value in the
                 # vocabulary
-                if isinstance(new_value, unicode):
-                    new_value = new_value.encode('utf-8')
-                new_value = b2a_qp(new_value)
-                values.append(new_value)
+                values.append(as_keyword_token(new_value))
 
             return values and list(set(values)) or default
 
@@ -213,16 +210,14 @@ class KeywordWidget(SelectWidget):
 
         for new_value in self.get_new_values_from_request():
             if new_value not in simple_vocbaulary.by_value:
-
                 # Vocabulary term tokens *must* be 7 bit values, titles *must*
                 # be unicode.
                 # Value needs to be a utf-8 str, only hell knows why.
                 # IMHO this should depend on the source. We're gonna have
                 # trouble with this in the future.
-                new_token = new_value
+                new_token = as_keyword_token(new_value)
                 if isinstance(new_value, unicode):
-                    new_value = new_token = new_value.encode('utf-8')
-                new_token = b2a_qp(new_token)
+                    new_value = new_value.encode('utf-8')
                 terms.append(
                     SimpleTerm(new_value, new_token, safe_unicode(new_value)))
 

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -175,33 +175,19 @@ class KeywordWidget(SelectWidget):
         self.cleanup_request()
 
         values = super(KeywordWidget, self).extract(default=default)
-
-        if not self.show_add_term_field():
+        if values is NOVALUE or not self.show_add_term_field():
             return values
 
-        else:
-            # Adding new keywords, which are not in the vocab/source
-            if (self.name + '_new' not in self.request and
-                    self.name + '-empty-marker' in self.request):
-                return []
+        # Adding new keywords, which are not in the vocab/source
+        if (self.name + '_new' not in self.request and
+                self.name + '-empty-marker' in self.request):
+            return []
 
-            new_values = self.get_new_values_from_request()
+        tokens = set(values)
+        for new_value in self.get_new_values_from_request():
+            tokens.add(as_keyword_token(new_value))
 
-            if values is default:
-                values = []
-            else:
-                # We need to remove the new added keywords from extracted
-                # values, since they need to be processed separately.
-                # This happens if the select2 plugin has the tag option
-                # activated
-                values = [val for val in values if val not in new_values]
-
-            for new_value in new_values:
-                # The new values needs to fit the token value in the
-                # vocabulary
-                values.append(as_keyword_token(new_value))
-
-            return values and list(set(values)) or default
+        return list(tokens) if tokens else default
 
     def updateTerms(self):
         super(KeywordWidget, self).updateTerms()

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -195,8 +195,8 @@ class KeywordWidget(SelectWidget):
                 # vocabulary
                 if isinstance(new_value, unicode):
                     new_value = new_value.encode('utf-8')
-                    new_value = b2a_qp(new_value)
-                    values.append(new_value)
+                new_value = b2a_qp(new_value)
+                values.append(new_value)
 
             return values and values or default
 

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -28,6 +28,12 @@ def is_list_type_field(field):
         return False
 
 
+def as_keyword_token(value):
+    if isinstance(value, unicode):
+        value = value.encode('utf-8')
+    return b2a_qp(value)
+
+
 class KeywordWidget(SelectWidget):
 
     klass = u'keyword-widget'
@@ -198,7 +204,7 @@ class KeywordWidget(SelectWidget):
                 new_value = b2a_qp(new_value)
                 values.append(new_value)
 
-            return values and values or default
+            return values and list(set(values)) or default
 
     def updateTerms(self):
         super(KeywordWidget, self).updateTerms()


### PR DESCRIPTION
This PR fixes an issue with keywords that contain non-ascii characters being duplicated after encountering at least one validation error on the form they are created with.

Also it refactors and simplifies control flow of `extract` and introduces a helper function to generate the token for the vocabulary term.

Fixes #11.

Before this PR broken, tags with e.g. umlauts were duplicated when creating the content after encountering a validation error in the form before saving:

![screen shot 2017-03-07 at 16 14 48](https://cloud.githubusercontent.com/assets/736583/23662994/8f32c45a-0351-11e7-916c-4737a481bf15.png)


