### PR TITLE
Implement async option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Introduction
 2. A ``ChoicePlus`` field, which allows new terms. This is prevents us from making a specific, complicated source, which allow new items.
 3. Render a additional ``New Entry`` textarea for new terms.
 4. Uses tags feature of select 2 to add new keywords.
+5. A async option to get the selectable options with the select2 ajax options.
 
 The widget supports schema.Choice, schema.Tuple and schema.List fields.
 
@@ -45,6 +46,28 @@ New terms are than added as unicode instead of utf-8.
     )
 
 
+Async option
+------------
+
+The async option can only be used if the source is a IQuerySource from z3c.formwidget.query.interfaces.
+This interface extends the ISource specification by a `search` method, which is essential for the async option.
+
+Basically if `async=True` the select2 Widget asks a search endpoint for possible options by a given search term.
+Further the search endpoint queries the `IContentSourceBinder` defined on the field.
+
+::
+
+    directives.widget('async', KeywordFieldWidget, async=True)
+    async = schema.Tuple(
+        title=u'Some async values',
+        value_type=ChoicePlus(
+            source=MySourceBinder(),
+            ),
+        required=False,
+        missing_value=(),
+    )
+
+
 Primary Use-Case
 ----------------
 
@@ -71,12 +94,6 @@ There are several other z3c form widgets for plone 4.x, which provides a similar
 - They do not fit the primary Use-Case.
 
 Further you can configure the select2 plugin as you wish.
-
-
-TODO
-----
-
-- Implement async option
 
 
 Compatibility

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement new async option.
+  [mathias.leimgruber]
 
 
 1.2.0 (2017-04-24)

--- a/ftw/keywordwidget/behavior.py
+++ b/ftw/keywordwidget/behavior.py
@@ -1,4 +1,5 @@
 from ftw.keywordwidget.field import ChoicePlus
+from ftw.keywordwidget.vocabularies import KeywordSearchableSourceBinder
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from plone.app.dexterity import PloneMessageFactory as _PMF
 from plone.app.dexterity.behaviors.metadata import MetadataBase
@@ -95,5 +96,17 @@ class IKeywordUseCases(model.Schema):
         required=False,
         missing_value=(),
     )
+
+    directives.widget('async', KeywordFieldWidget, async=True)
+    async = schema.Tuple(
+        title=u'async',
+        value_type=schema.Choice(
+            title=u"Multiple",
+            source=KeywordSearchableSourceBinder(),
+            ),
+        required=False,
+        missing_value=(),
+    )
+
 
 alsoProvides(IKeywordUseCases, IFormFieldProvider)

--- a/ftw/keywordwidget/configure.zcml
+++ b/ftw/keywordwidget/configure.zcml
@@ -83,4 +83,12 @@
         directory="./upgrades/select2js"
         />
 
+    <browser:page
+        for="z3c.form.interfaces.ISelectWidget"
+        name="search"
+        class=".search.SearchSource"
+        permission="zope2.View"
+        />
+        
+
 </configure>

--- a/ftw/keywordwidget/configure.zcml
+++ b/ftw/keywordwidget/configure.zcml
@@ -84,7 +84,7 @@
         />
 
     <browser:page
-        for="z3c.form.interfaces.ISelectWidget"
+        for="ftw.keywordwidget.widget.IKeywordWidget"
         name="search"
         class=".search.SearchSource"
         permission="zope2.View"

--- a/ftw/keywordwidget/locales/de/LC_MESSAGES/ftw.keywordwidget.po
+++ b/ftw/keywordwidget/locales/de/LC_MESSAGES/ftw.keywordwidget.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-08 16:05+0000\n"
+"POT-Creation-Date: 2017-04-24 08:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,6 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/keywordwidget/widget.py:54
+msgid " or more characters"
+msgstr " oder mehr Zeichen ein"
+
 #: ./ftw/keywordwidget/configure.zcml:62
 msgid "Adds keywords/tags/subjects"
 msgstr ""
@@ -22,13 +26,25 @@ msgstr ""
 msgid "Categorization with keywordwidget"
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:40
+#: ./ftw/keywordwidget/widget.py:52
+msgid "Load more results..."
+msgstr "Mehr Resultate laden..."
+
+#: ./ftw/keywordwidget/widget.py:50
 msgid "New"
 msgstr "Neu"
 
-#: ./ftw/keywordwidget/widget.py:39
+#: ./ftw/keywordwidget/widget.py:49
 msgid "No result found"
 msgstr "Kein Resultat gefunden"
+
+#: ./ftw/keywordwidget/widget.py:53
+msgid "Please enter "
+msgstr "Bitte geben Sie "
+
+#: ./ftw/keywordwidget/widget.py:51
+msgid "Searching..."
+msgstr "Suche..."
 
 #: ./ftw/keywordwidget/configure.zcml:69
 msgid "Some demo Use-Cases"
@@ -51,19 +67,19 @@ msgid "ftw.keywordwidget default"
 msgstr ""
 
 #. Default: "New entries"
-#: ./ftw/keywordwidget/templates/keyword_input.pt:49
+#: ./ftw/keywordwidget/templates/keyword_input.pt:50
 msgid "label_new_tokens"
 msgstr "Neuer Eintrag (Pro Zeile wird ein neuer Eintrag erstellt)"
 
-#: ./ftw/keywordwidget/widget.py:37
+#: ./ftw/keywordwidget/widget.py:47
 msgid "no value"
 msgstr "Kein Wert"
 
-#: ./ftw/keywordwidget/widget.py:124
+#: ./ftw/keywordwidget/widget.py:198
 msgid "select a value ..."
 msgstr "Einen Eintrag auswählen..."
 
-#: ./ftw/keywordwidget/widget.py:38
+#: ./ftw/keywordwidget/widget.py:48
 msgid "select some values ..."
 msgstr "Mehrere Einträge auswählen ..."
 

--- a/ftw/keywordwidget/locales/ftw.keywordwidget.pot
+++ b/ftw/keywordwidget/locales/ftw.keywordwidget.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-08 16:05+0000\n"
+"POT-Creation-Date: 2017-04-24 08:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,6 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/keywordwidget/widget.py:54
+msgid " or more characters"
+msgstr ""
+
 #: ./ftw/keywordwidget/configure.zcml:62
 msgid "Adds keywords/tags/subjects"
 msgstr ""
@@ -22,12 +26,24 @@ msgstr ""
 msgid "Categorization with keywordwidget"
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:40
+#: ./ftw/keywordwidget/widget.py:52
+msgid "Load more results..."
+msgstr ""
+
+#: ./ftw/keywordwidget/widget.py:50
 msgid "New"
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:39
+#: ./ftw/keywordwidget/widget.py:49
 msgid "No result found"
+msgstr ""
+
+#: ./ftw/keywordwidget/widget.py:53
+msgid "Please enter "
+msgstr ""
+
+#: ./ftw/keywordwidget/widget.py:51
+msgid "Searching..."
 msgstr ""
 
 #: ./ftw/keywordwidget/configure.zcml:69
@@ -51,19 +67,19 @@ msgid "ftw.keywordwidget default"
 msgstr ""
 
 #. Default: "New entries"
-#: ./ftw/keywordwidget/templates/keyword_input.pt:49
+#: ./ftw/keywordwidget/templates/keyword_input.pt:50
 msgid "label_new_tokens"
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:37
+#: ./ftw/keywordwidget/widget.py:47
 msgid "no value"
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:124
+#: ./ftw/keywordwidget/widget.py:198
 msgid "select a value ..."
 msgstr ""
 
-#: ./ftw/keywordwidget/widget.py:38
+#: ./ftw/keywordwidget/widget.py:48
 msgid "select some values ..."
 msgstr ""
 

--- a/ftw/keywordwidget/search.py
+++ b/ftw/keywordwidget/search.py
@@ -26,15 +26,17 @@ class SearchSource(BrowserView):
         batch = Batch.fromPagenumber(items=source.search(query),
                                      pagesize=pagesize,
                                      pagenumber=page)
+
         return json.dumps(
             {
-                'items': map(self._term_to_dict, batch),
+                'results': map(self._term_to_dict, batch),
                 'total_count': len(batch),
-                'page': page
+                'page': page,
+                'pagination': {'more': (page * pagesize) < len(batch)}
             }
         )
 
     def _term_to_dict(self, term):
-        return {'token': term.token,
-                'value': term.value,
-                'title': term.title and term.title or term.value}
+        return {'_resultId': term.token,
+                'id': term.value,
+                'text': term.title and term.title or term.value}

--- a/ftw/keywordwidget/search.py
+++ b/ftw/keywordwidget/search.py
@@ -1,0 +1,30 @@
+from Products.Five.browser import BrowserView
+import json
+
+
+class SearchSource(BrowserView):
+
+    def __init__(self, context, request):
+        super(SearchSource, self).__init__(context, request)
+        self.widget = self.context
+
+    def __call__(self):
+        self.request.response.setHeader('Content-Type', 'application/json')
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+
+        query = self.request.get('q', None)
+
+        if not query:
+            json.dumps([])
+
+        self.widget.update()
+        source = self.widget.choice_field.source(self.widget.context)
+
+        return json.dumps(
+            map(self._term_to_dict, source.search(query))
+        )
+
+    def _term_to_dict(self, term):
+        return {'token': term.token,
+                'value': term.value,
+                'title': term.title and term.title or term.value}

--- a/ftw/keywordwidget/templates/keyword.js.pt
+++ b/ftw/keywordwidget/templates/keyword.js.pt
@@ -3,6 +3,7 @@ $(function() {
     function initSelect2(widget){
         var config = widget.data("select2config");
         var i18n = config.i18n;
+        var ajaxOptions = widget.data("ajaxoptions");
 
         // Update language from Backend
         config.language = {
@@ -16,19 +17,40 @@ $(function() {
 
         // Special template to indicate new terms
         config.templateResult = function (data) {
+
           if (!data._resultId) {
+
             // Since this is hacked into a pt, we cannot use html tags :-(
             return $(document.createElement('span'))
               .text(data.text)
               .addClass('newTag')
               .add($(document.createElement('span')).addClass('newTagHint').text(i18n.label_new));
           } else {
-            return data.text;  
+            return data.text;
           }
+        };
+
+        // Add and Update config for remote data
+        if (ajaxOptions) {
+          config.ajax = {
+            data: function (params) {
+              return {
+                q: params.term,
+                page: params.page || 1
+              };
+            },
+            processResults: function (data, params) {
+              params.page = params.page || 1;
+              return data;
+            },
+            cache: true
+          };
+
+          $.extend(config.ajax, ajaxOptions);
         }
 
         $(widget).select2(config).on('change', function(event){
-            var newTermsField = $(this).parent().find('[id$="_new"]')
+            var newTermsField = $(this).parent().find('[id$="_new"]');
             var newTerms = $(this).find('[data-select2-tag="true"]');
             var newTermsText = $.map(newTerms, function(val, i){ return val.value; });
             newTermsField.val(newTermsText.join('\n'));

--- a/ftw/keywordwidget/templates/keyword.js.pt
+++ b/ftw/keywordwidget/templates/keyword.js.pt
@@ -9,6 +9,19 @@ $(function() {
         config.language = {
           noResults: function(){
             return i18n.label_no_result;
+          },
+          searching: function () {
+            return i18n.label_searching;
+          },
+          loadingMore: function () {
+            return i18n.label_loading_more;
+          },
+          inputTooShort: function (args) {
+            var remainingChars = args.minimum - args.input.length;
+
+            var message = i18n.label_tooshort_prefix + remainingChars + i18n.label_tooshort_postfix;
+
+            return message;
           }
         };
 

--- a/ftw/keywordwidget/templates/keyword.js.pt
+++ b/ftw/keywordwidget/templates/keyword.js.pt
@@ -17,17 +17,18 @@ $(function() {
 
         // Special template to indicate new terms
         config.templateResult = function (data) {
-
-          if (!data._resultId) {
-
-            // Since this is hacked into a pt, we cannot use html tags :-(
-            return $(document.createElement('span'))
-              .text(data.text)
-              .addClass('newTag')
-              .add($(document.createElement('span')).addClass('newTagHint').text(i18n.label_new));
-          } else {
-            return data.text;
-          }
+          if (!data.loading) {
+            // Nested if, since we cannot use amp in a templage... grml... will change this soon.
+            if (!data._resultId) {
+                // Since this is hacked into a pt, we cannot use html tags :-(
+                return $(document.createElement('span'))
+                  .text(data.text)
+                  .addClass('newTag')
+                  .add($(document.createElement('span')).addClass('newTagHint').text(i18n.label_new));
+              } else {
+                return data.text;
+              }              
+            }
         };
 
         // Add and Update config for remote data

--- a/ftw/keywordwidget/templates/keyword_input.pt
+++ b/ftw/keywordwidget/templates/keyword_input.pt
@@ -26,6 +26,7 @@
                             onchange view/onchange;
                             multiple view/multiple;
                             data-select2config view/config_json;
+                            data-ajaxoptions view/ajax_options_json;
                             size view/size">
 
         <tal:block repeat="item view/items">

--- a/ftw/keywordwidget/templates/keyword_input.pt
+++ b/ftw/keywordwidget/templates/keyword_input.pt
@@ -25,7 +25,7 @@
                             onblur view/onblur;
                             onchange view/onchange;
                             multiple view/multiple;
-                            data-select2config view/js_config;
+                            data-select2config view/config_json;
                             size view/size">
 
         <tal:block repeat="item view/items">

--- a/ftw/keywordwidget/tests/test_different_cases.py
+++ b/ftw/keywordwidget/tests/test_different_cases.py
@@ -100,3 +100,31 @@ class TestKeywordWidget(FunctionalTestCase):
         tags = browser.find_field_by_text(u'UnicodeTags')
         self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
                               tuple(tags.value))
+
+
+class TestAsyncOption(FunctionalTestCase):
+    def setUp(self):
+        super(TestAsyncOption, self).setUp()
+        self.grant('Manager')
+        additional_behaviors = [
+            'ftw.keywordwidget.behavior.IKeywordCategorization',
+            'ftw.keywordwidget.behavior.IKeywordUseCases',
+        ]
+        self.setup_fti(additional_behaviors=additional_behaviors)
+        transaction.commit()
+
+    @browsing
+    def test_async_render_only_selected_items(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib')
+                         .having(async=('abc', 'zzzzzz', 'lorem')))
+
+        browser.login().visit(content, view='edit')
+        field = browser.find_field_by_text('async')
+        self.assertListEqual(list(field.value), field.options_values)
+

--- a/ftw/keywordwidget/tests/test_different_cases.py
+++ b/ftw/keywordwidget/tests/test_different_cases.py
@@ -169,18 +169,18 @@ class TestAsyncOption(FunctionalTestCase):
         self.assertIn('page', result)
         self.assertEquals(result['page'], 1)
 
-        self.assertIn('items', result)
-        self.assertEquals([{'token': u'bar',
-                            'value': u'bar',
-                            'title': u'bar'},
-                           {'token': u'baz',
-                            'value': u'baz',
-                            'title': u'baz'}, ],
-                          result['items'])
+        self.assertIn('results', result)
+        self.assertEquals([{'_resultId': u'bar',
+                            'id': u'bar',
+                            'text': u'bar'},
+                           {'_resultId': u'baz',
+                            'id': u'baz',
+                            'text': u'baz'}, ],
+                          result['results'])
 
         self.portal.REQUEST.set('q', 'dummy')
         result = json.loads(self._get_search_view(content))
-        self.assertEquals([], result['items'])
+        self.assertEquals([], result['results'])
 
     def test_search_endpoint_batch_result(self):
         content = create(Builder('sample content')
@@ -192,22 +192,23 @@ class TestAsyncOption(FunctionalTestCase):
         self.portal.REQUEST.set('page', '1')
         result = json.loads(self._get_search_view(content))
 
-        self.assertEquals(5, len(result['items']))
+        self.assertEquals(5, len(result['results']))
         self.assertEquals(19, result['total_count'])
         self.assertEquals([u'1', u'10', u'11', u'12', u'13'],
-                          self._get_values(result['items']))
+                          self._get_values(result['results']))
 
         self.portal.REQUEST.set('q', '1')
         self.portal.REQUEST.set('pagesize', '5')
         self.portal.REQUEST.set('page', '3')
         result = json.loads(self._get_search_view(content))
-        self.assertEquals(5, len(result['items']))
+
+        self.assertEquals(5, len(result['results']))
         self.assertEquals(19, result['total_count'])
         self.assertEquals([u'19', u'21', u'31', u'41', u'51'],
-                          self._get_values(result['items']))
+                          self._get_values(result['results']))
 
     def _get_values(self, items):
-        return map(lambda item: item['value'], items)
+        return map(lambda item: item['id'], items)
 
     def _get_search_view(self, context):
         form = context.unrestrictedTraverse('@@edit').form_instance

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -53,6 +53,7 @@ class KeywordWidget(SelectWidget):
 
     # KeywordWidget specific
     js_config = None
+    config_json = ''
     choice_field = None
     add_permission = None
     new_terms_as_unicode = None
@@ -163,7 +164,7 @@ class KeywordWidget(SelectWidget):
         if self.js_config:
             default_config.update(self.js_config)
 
-        self.js_config = json.dumps(default_config)
+        self.config_json = json.dumps(default_config)
 
     def update_multivalued_property(self):
         if not is_list_type_field(self.field):

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -10,6 +10,7 @@ from z3c.form.interfaces import DISPLAY_MODE
 from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import INPUT_MODE
+from z3c.form.interfaces import ISelectWidget
 from z3c.form.interfaces import NOVALUE
 from z3c.form.widget import FieldWidget
 from z3c.formwidget.query.interfaces import IQuerySource
@@ -38,6 +39,11 @@ def as_keyword_token(value):
     return b2a_qp(value)
 
 
+class IKeywordWidget(ISelectWidget):
+    """Marker interface for the Keywordwidget"""
+
+
+@implementer(IKeywordWidget)
 class KeywordWidget(SelectWidget):
 
     klass = u'keyword-widget'

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -164,6 +164,14 @@ class KeywordWidget(SelectWidget):
         if self.js_config:
             default_config.update(self.js_config)
 
+        if self.async:
+            self.ajax_options_json = json.dumps(
+                {'url': '{}/++widget++{}/search'.format(self.request.getURL(),
+                                                        self.name),
+                 'dataType': 'json',
+                 'delay': 250}
+            )
+
         self.config_json = json.dumps(default_config)
 
     def update_multivalued_property(self):

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -12,9 +12,11 @@ from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import INPUT_MODE
 from z3c.form.interfaces import NOVALUE
 from z3c.form.widget import FieldWidget
+from z3c.formwidget.query.interfaces import IQuerySource
 from zope import schema
 from zope.i18n import translate
 from zope.interface import implementer
+from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import ITitledTokenizedTerm
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
@@ -114,8 +116,19 @@ class KeywordWidget(SelectWidget):
                 values.remove(new_value)
         self.request.set(self.name, values)
 
+    def _validate_source_for_async(self):
+        source = self.choice_field.source
+        if IContextSourceBinder.providedBy(source):
+            source = source(self.context)
+            if IQuerySource.providedBy(source):
+                return
+        raise(TypeError('A IContextSourceBinder with IQuerySource is needed'))
+
     def update(self):
         self.get_choice_field()
+
+        if self.async:
+            self._validate_source_for_async()
 
         super(KeywordWidget, self).update()
 

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -54,6 +54,7 @@ class KeywordWidget(SelectWidget):
     # KeywordWidget specific
     js_config = None
     config_json = ''
+    ajax_options_json = ''
     choice_field = None
     add_permission = None
     new_terms_as_unicode = None
@@ -160,6 +161,9 @@ class KeywordWidget(SelectWidget):
         if self.show_add_term_field():
             default_config['tags'] = True
             default_config['tokenSeparators'] = [',']
+
+        if self.async:
+            default_config['minimumInputLength'] = 3
 
         if self.js_config:
             default_config.update(self.js_config)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -47,7 +47,12 @@ class KeywordWidget(SelectWidget):
     noValueMessage = _('no value')
     promptMessage = _('select some values ...')
     promptNoresultFound = _('No result found')
-    labelNew = _('New')
+    label_new = _(u'New')
+    label_searching = _(u'Searching...')
+    label_loading_more = _('Load more results...')
+    label_tooshort_prefix = _('Please enter ')
+    label_tooshort_postfix = _(' or more characters')
+
     multiple = 'multiple'
     size = 10
 
@@ -151,8 +156,16 @@ class KeywordWidget(SelectWidget):
                                                context=self.request),
                 'label_no_result': translate(self.promptNoresultFound,
                                              context=self.request),
-                'label_new': translate(self.labelNew,
-                                       context=self.request)
+                'label_new': translate(self.label_new,
+                                       context=self.request),
+                'label_searching': translate(self.label_searching,
+                                             context=self.request),
+                'label_loading_more': translate(self.label_loading_more,
+                                                context=self.request),
+                'label_tooshort_prefix': translate(self.label_tooshort_prefix,
+                                                   context=self.request),
+                'label_tooshort_postfix': translate(self.label_tooshort_postfix,
+                                                    context=self.request),
             },
             'width': '300px',
             'allowClear': not self.field.required and not self.multiple,


### PR DESCRIPTION
- This implementation depends on the `IQuerySource` of from `z3c.formwidget.query`
IQuerySource is a special implementation of ISource, which has a `search` method. The search method is required für a async search of the result.

- If `async=True` the ContextSourceBinder needs to return a IQuerySource, otherwise the widget cannot be rendered. 

- If `async=True` it's not possible to add new elements.

- The backend only loads the selected items by calling `getTerm` (aka getItemByValue), which should be fast.

-  The default options of `ajax` of select2 are:
  ```
                {'url': 'url/to/search/endpoint',
                 'dataType': 'json',
                 'delay': 250}
   ```


![async](https://cloud.githubusercontent.com/assets/437933/25326634/56b68be8-28d1-11e7-9f1c-7c4fb23d4feb.gif)
