### PR TITLE
Add testbrowser widget for Keywordwidgets with async option.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Add testbrowser widget for Keywordwidgets with async option.
+  [mathias.leimgruber]
+
 - No longer load keywordwidget JS inline in the widget.
   [mathias.leimgruber]
 

--- a/ftw/keywordwidget/tests/__init__.py
+++ b/ftw/keywordwidget/tests/__init__.py
@@ -9,6 +9,7 @@ from plone.supermodel import model
 from unittest2 import TestCase
 from zope.interface import implements
 from zope.interface import Interface
+import ftw.keywordwidget.tests.widget
 import transaction
 
 

--- a/ftw/keywordwidget/tests/test_different_cases.py
+++ b/ftw/keywordwidget/tests/test_different_cases.py
@@ -134,6 +134,44 @@ class TestAsyncOption(FunctionalTestCase):
         field = browser.find_field_by_text('async')
         self.assertListEqual(list(field.value), field.options_values)
 
+    @browsing
+    def test_async_option_is_selectable_but_not_rendered(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib'))
+
+        browser.login().visit(content, view='edit')
+        field = browser.find_field_by_text('async')
+        self.assertFalse(tuple(field.value), 'Expect no selectable options')
+
+        form = browser.find_form_by_field('async')
+        form.find_widget('async').fill(['foo', 'bar'])
+        form.submit()
+
+        self.assertSequenceEqual(['foo', 'bar'], content.async)
+
+    @browsing
+    def test_async_option_terms_not_in_source_are_ignored(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib'))
+
+        browser.login().visit(content, view='edit')
+
+        form = browser.find_form_by_field('async')
+        form.find_widget('async').fill(['New', 'New2'])
+        form.submit()
+
+        self.assertFalse(content.async, 'Expect nothing in field async')
+
     def test_async_option_only_works_with_IQuerySource(self):
 
         @implementer(IContextSourceBinder)

--- a/ftw/keywordwidget/tests/widget.py
+++ b/ftw/keywordwidget/tests/widget.py
@@ -1,0 +1,35 @@
+from ftw.testbrowser.widgets.base import PloneWidget
+from ftw.testbrowser.widgets.base import widget
+from lxml import etree
+
+
+@widget
+class AsyncKeywordWidget(PloneWidget):
+
+    @staticmethod
+    def match(node):
+        if not node.tag == 'div' or 'field' not in node.classes:
+            return False
+        return bool(node.css('.keyword-widget[data-ajaxoptions*="url"]'))
+
+    def fill(self, values):
+        select = self.css('select').first
+        multiple = select.attrib.get('multiple', None) == 'multiple'
+
+        if isinstance(values, basestring):
+            values = [values]
+
+        if not multiple and len(values) > 1:
+            raise ValueError('Expect only one item, since the field is '
+                             'single valued')
+
+        # Clear options
+        for item in self.css('option'):
+            item.node.getparent().remove(item.node)
+
+        for value in values:
+            option = etree.Element('option')
+            option.attrib['value'] = value
+            option.attrib['selected'] = 'selected'
+            option.text = value
+            select.append(option)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -245,7 +245,7 @@ class KeywordWidget(SelectWidget):
 
         if self.async:
             # It's not possible to add new terms in async mode
-            return
+            return self.terms
 
         simple_vocbaulary = self.terms.terms
         terms = self.terms.terms._terms


### PR DESCRIPTION
This makes it simpler to write tests with the Keywordwidget, which has async option active.

Issue:
There are no options available after rendering the form, since the possible options are collected asynchronous and inserted into the DOM by JS.

The widget implemented in this PR makes exactly the same but with lxml.

Implementation issue:
Since the markup is a regular select field it's not possible to let the testbrowser automatically fill the form using the right `PloneWidget`. In tests you need to use the implemented PloneWidget explicitly.

```python 
        form = browser.find_form_by_field('async')
        form.find_widget('async').fill(['foo', 'bar'])
        form.submit()
```

This pr also fixes I regression as I wrote tests to make sure everything works as expected. The `updateTerms` method accidentally returned nothing with the async option enabled. This is wrong since updateTerms needs to return the actual terms from the super call.