### PR TITLE
BugFix: Get stored terms by token not by value, since self.value stores the widget value.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix: Get stored terms by token not by value, since self.value stores the widget value.
+  [mathias.leimgruber]
 
 
 1.3.0 (2017-05-11)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -308,7 +308,7 @@ class KeywordWidget(SelectWidget):
                  'selected': selected})
 
         if self.async:
-            terms = [self.terms.getTerm(v) for v in self.value]
+            terms = [self.terms.getTermByToken(v) for v in self.value]
         else:
             terms = self.terms
 


### PR DESCRIPTION
Check `z3c.form.widget.Widget.update`