### PR TITLE
Remove superfluous `for` attribute for a behavior without a `factory` configured.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removed superfluous `for` attribute for a behavior without a `factory` configured. [phgross]
 
 
 1.3.1 (2017-06-14)

--- a/ftw/keywordwidget/configure.zcml
+++ b/ftw/keywordwidget/configure.zcml
@@ -65,7 +65,6 @@
         title="Test behavior for keywordwidget Use-Cases"
         description="Some demo Use-Cases"
         provides=".behavior.IKeywordUseCases"
-        for="plone.dexterity.interfaces.IDexterityContent"
         />
 
     <utility
@@ -89,6 +88,6 @@
         class=".search.SearchSource"
         permission="zope2.View"
         />
-        
+
 
 </configure>


### PR DESCRIPTION
This removes the following warning when starting up the instance:
`WARNING plone.behavior Specifying 'for' in behavior 'Test behavior for keywordwidget Use-Cases' if no 'factory' is given has no effect and is superfluous.`

See https://github.com/plone/plone.behavior/blob/master/plone/behavior/metaconfigure.py#L154-L156.