### PR TITLE
BugFix: No longer add items if they're not "really" selected.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix: No longer add items if they're not "really" selected.
+  [mathias.leimgruber]
 
 
 1.3.2 (2017-07-11)

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -60,7 +60,7 @@ $(function() {
 
         $(widget).select2(config).on('change', function(event){
             var newTermsField = $(this).parent().find('[id$="_new"]');
-            var newTerms = $(this).find('[data-select2-tag="true"]');
+            var newTerms = $(this).data('select2').val() || [];
             var newTermsText = $.map(newTerms, function(val, i){ return val.value; });
             newTermsField.val(newTermsText.join('\n'));
         }).parent().addClass(config.tags ? 'select2tags' : '');


### PR DESCRIPTION
Before:
If you start typing a term and select a match, the typed term was also added to the select. 

After:
Get the new value from the select widget itself. 