### PR TITLE
Automatically open the menu on single value fields + BugFix

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix: Fix JS error on single value fields. [mathias.leimgruber]
 
 
 1.3.3 (2017-07-31)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Automatically open the search menu for single value fields. [mathias.leimgruber]
+
 - BugFix: Fix JS error on single value fields. [mathias.leimgruber]
 
 

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -60,6 +60,10 @@ $(function() {
 
         $(widget).select2(config).on('change', function(event){
             var newTermsField = $(this).parent().find('[id$="_new"]');
+            if (newTermsField.length === 0) {
+              return;
+            }
+
             var newTerms = $(this).data('select2').val() || [];
             var newTermsText = $.map(newTerms, function(val, i){ return val.value; });
             newTermsField.val(newTermsText.join('\n'));

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -96,4 +96,8 @@ $(function() {
       });
     });
 
+    $(document).on('focus', '.select2-selection.select2-selection--single', function(event){
+      $(this).parents('.select2-container').prev().select2('open');
+    });
+
 });


### PR DESCRIPTION
If the single value field gets focused it automatically opens the menu (incl. the searchbox).
The prevents us from a additional click.

The reason for hackish implementation of the triggering the menu on focus is https://github.com/select2/select2/issues/1908
focus on select2 is currently not supported 😢 

And I stumbled over a bug while selecting a single item. 
![kwsinglevalue](https://user-images.githubusercontent.com/437933/29862405-c120117a-8d6c-11e7-8525-f26a210ce3a1.gif)
