### PR TITLE
Fix adding new terms

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug, which I introduced in 1.3.3 and miss to catch in 1.3.4 :-( [mathias.leimgruber]
 
 
 1.3.4 (2017-08-30)

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -65,8 +65,7 @@ $(function() {
             }
 
             var newTerms = $(this).data('select2').val() || [];
-            var newTermsText = $.map(newTerms, function(val, i){ return val.value; });
-            newTermsField.val(newTermsText.join('\n'));
+            newTermsField.val(newTerms.join('\n'));
         }).parent().addClass(config.tags ? 'select2tags' : '');
     }
 


### PR DESCRIPTION
The bug was introduced in 1.3.3, `select2.val()`  returns a list of strings not an object.
In 1.3.3 and 1.3.4 it was no longer possible to add new keywords.