### PR TITLE
Add possiblity to add templates for the select2 widget.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Introduction
 3. Render a additional ``New Entry`` textarea for new terms.
 4. Uses tags feature of select 2 to add new keywords.
 5. A async option to get the selectable options with the select2 ajax options.
+6. Custom templates for results and selected items
 
 The widget supports schema.Choice, schema.Tuple and schema.List fields.
 
@@ -26,8 +27,8 @@ In DX "Subject" is a accessor for "subject", which returns utf-8.
 The Plone KeywordsVocabulary builds it's terms using the catalog value, which is utf-8 in case of the Subject index. By convention indexed values should be always utf-8 and DX values should always be unicode.
 
 This actually means in the case of the KeywordsVocabulary the value needs to be stored as utf-8, because the vocabulary values are encoded as utf-8.
-The SequenceWidget fieldToWidget converter has a sanity check included, which makes sure only field values, which are also in vocabulary are computed. 
-And this means if you store new terms as unicode values, the whole thing falls apart. Currently the widget makes sure to work perfectly with the "Subject" index, which relays on utf-8 values, which is not common with DX types. 
+The SequenceWidget fieldToWidget converter has a sanity check included, which makes sure only field values, which are also in vocabulary are computed.
+And this means if you store new terms as unicode values, the whole thing falls apart. Currently the widget makes sure to work perfectly with the "Subject" index, which relays on utf-8 values, which is not common with DX types.
 
 Beside of the primary Use-Case, the widget also supports vocabularies, with unicode values, but this needs to be configured separately on the widget.
 New terms are than added as unicode instead of utf-8.
@@ -175,7 +176,62 @@ But you it's not installed with the default profile, because you may already hav
 select2 JS installed for other purpose.
 If you need select2 you can install the ``ftw.keywordwidget Install select2 jquery plugin`` profile.
 
+Templating
+----------
 
+You can define your own templates for each plone-widget or you replace the default widget for
+all your used keywordwidgets.
+
+First of all, you need to create a new templates (take a look at the select2-documentation to
+see what a template is in the select2-context).
+
+.. code:: javascript
+
+    function myPurpleTemplate(data) {
+        return $('<span style="background-color:purple" />').text(data.text);
+    }
+    function myBlueTemplate(data) {
+        return $('<span style="background-color:blue" />').text(data.text);
+    }
+
+then you need to register it
+
+
+.. code:: javascript
+
+    $(document).on('ftwKeywordWidgetInit', function(e) {
+      window.ftwKeywordWidget.registerTemplate('purple', myPurpleTemplate);
+      window.ftwKeywordWidget.registerTemplate('blue', myBlueTemplate);
+    });
+
+
+and use it in your desired widgets
+
+.. code:: python
+
+    directives.widget('colours', KeywordFieldWidget,
+                      template_selection='purple'
+                      template_result='blue')
+    colours = schema.Tuple(
+        title=u'Some colours',
+        value_type=ChoicePlus(source=MySourceBinder()),
+        required=False,
+        missing_value=(),
+    )
+
+If you wish to override the default-template, just register a template for
+
+`defaultResultTemplate` or `defaultSelectionTemplate` depending on which defaulttemplate you want to override.
+
+.. code:: javascript
+
+    function myBlackTemplate(data) {
+        return $('<span style="background-color:black" />').text(data.text);
+    }
+
+    $(document).on('ftwKeywordWidgetInit', function(e) {
+      window.ftwKeywordWidget.registerTemplate('defaultResultTemplate', myBlackTemplate);
+    });
 
 Development
 ===========

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -1,9 +1,37 @@
-$(function() {
+window.ftwKeywordWidget = function($) {
 
-    function initSelect2(widget){
+    "use strict";
+
+    var self = {};
+    var templates = {};
+
+    var init = function() {
+      document.dispatchEvent(new Event('ftwKeywordWidgetInit'));
+    };
+
+    var registerTemplate = function(name, templateFunction) {
+        if (templates.hasOwnProperty(name)) {
+            console.warn("A template with the name '" + name + "' is alredy registred.");
+            return;
+        }
+        templates[name] = templateFunction;
+    };
+
+    var getTemplate = function(name) {
+        if (!templates.hasOwnProperty(name)) {
+            console.warn("There is no registered template for the name '" + name + "' " +
+                "Read the README for more information.");
+            return;
+        }
+        return templates[name];
+    };
+
+    var initWidget = function(widget) {
         var config = widget.data("select2config");
         var i18n = config.i18n;
         var ajaxOptions = widget.data("ajaxoptions");
+        var templateSelection = widget.data("templateSelection");
+        var templateResult = widget.data("templateResult");
 
         // Update language from Backend
         config.language = {
@@ -75,36 +103,42 @@ $(function() {
             });
             newTermsField.val(newSelectedTerms.join('\n'));
         }).parent().addClass(config.tags ? 'select2tags' : '');
-    }
+    };
 
-    window.ftwKeywordWidgetInitSelect2 = initSelect2;
+    self.initWidget = initWidget;
+    self.registerTemplate = registerTemplate;
+    self.getTemplate = getTemplate;
+    self.init = init;
 
-    $(window).load(function(){
-      if ($().select2 === undefined) {
-          console.warn('You need to make sure, that select2 jquery plugin is loaded!');
-      } else {
-        $('.keyword-widget:visible').each(function(index, widget){
-          ftwKeywordWidgetInitSelect2($(widget));
-        });
-      }
+    return self;
+}(jQuery);
+
+window.ftwKeywordWidget.init();
+
+$(window).load(function(){
+  if ($().select2 === undefined) {
+      console.warn('You need to make sure, that select2 jquery plugin is loaded!');
+  } else {
+    $('.keyword-widget:visible').each(function(index, widget){
+      window.ftwKeywordWidget.initWidget($(widget));
     });
+  }
+});
 
-    // select2 has issues to get right width of the placeholder element if the content is hidden and select2 gets initialized.
-    // See https://github.com/select2/select2/issues/291
-    $(document).on("click", "select.formTabs a, ul.formTabs a", function (e, index) {
-      $('.keyword-widget:visible').each(function(index, widget){
-        ftwKeywordWidgetInitSelect2($(widget));
-      });
-    });
+// select2 has issues to get right width of the placeholder element if the content is hidden and select2 gets initialized.
+// See https://github.com/select2/select2/issues/291
+$(document).on("click", "select.formTabs a, ul.formTabs a", function (e, index) {
+  $('.keyword-widget:visible').each(function(index, widget){
+    window.ftwKeywordWidget.initWidget($(widget));
+  });
+});
 
-    $(document).on("onLoad OverlayContentReloaded", ".overlay", function() {
-      $('.keyword-widget:visible').each(function(index, widget){
-        ftwKeywordWidgetInitSelect2($(widget));
-      });
-    });
+$(document).on("onLoad OverlayContentReloaded", ".overlay", function() {
+  $('.keyword-widget:visible').each(function(index, widget){
+    window.ftwKeywordWidget.initWidget($(widget));
+  });
+});
 
-    $(document).on('focus', '.select2-selection.select2-selection--single', function(event){
-      $(this).parents('.select2-container').prev().select2('open');
-    });
-
+$(document).on('focus', '.select2-selection.select2-selection--single', function(event){
+  $(this).parents('.select2-container').prev().select2('open');
 });

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -1,11 +1,11 @@
-window.ftwKeywordWidget = function($) {
+window.ftwKeywordWidget = (function($) {
 
     "use strict";
 
     var self = {};
     var templates = {};
 
-    var init = function() {
+    function init() {
 
         // Special template to indicate new terms
         registerTemplate("defaultResultTemplate", function (data) {
@@ -18,27 +18,38 @@ window.ftwKeywordWidget = function($) {
             }
         });
 
-        document.dispatchEvent(new Event('ftwKeywordWidgetInit'));
-    };
+        $(document).trigger("ftwKeywordWidgetInit");
+    }
 
-    var registerTemplate = function(name, templateFunction) {
+    function registerTemplate(name, templateFunction) {
         if (templates.hasOwnProperty(name)) {
             console.warn("A template with the name '" + name + "' is alredy registred.");
             return;
         }
-        templates[name] = templateFunction;
-    };
-
-    var getTemplate = function(name) {
-        if (!templates.hasOwnProperty(name)) {
-            console.warn("There is no registered template for the name '" + name + "' " +
-                "Read the README for more information.");
+        if (!$.isFunction(templateFunction)) {
+            console.warn("The given template is not a function. A template needs to be a function.");
             return;
         }
-        return templates[name];
-    };
+        templates[name] = templateFunction;
+    }
 
-    var initWidget = function(widget) {
+    function getTemplate(name, fallback) {
+        if (templates.hasOwnProperty(name)) {
+            return templates[name];
+        } else if (templates.hasOwnProperty(fallback)) {
+            return templates[fallback];
+        }
+        return null;
+    }
+
+    function setSelect2Template(config, name, template) {
+        if (!template) {
+            return;
+        }
+        config[name] = template;
+    }
+
+    function initWidget(widget) {
         var config = widget.data("select2config");
         var i18n = config.i18n;
         var ajaxOptions = widget.data("ajaxoptions");
@@ -68,15 +79,13 @@ window.ftwKeywordWidget = function($) {
         // Update placholder with translated string
         config.placeholder = i18n.label_placeholder;
 
-        if (templateResult) {
-            config.templateResult = this.getTemplate(templateResult);
-        } else {
-            config.templateResult = this.getTemplate('defaultResultTemplate');
-        }
+        // Register templateResult
+        setSelect2Template(config, "templateResult",
+                           this.getTemplate(templateResult, "defaultResultTemplate"));
 
-        if (templateSelection) {
-            config.templateSelection = this.getTemplate(templateSelection);
-        }
+        // Register templateSelection
+        setSelect2Template(config, "templateSelection",
+                           this.getTemplate(templateSelection, "defaultSelectionTemplate"));
 
         // Add and Update config for remote data
         if (ajaxOptions) {
@@ -114,7 +123,7 @@ window.ftwKeywordWidget = function($) {
             });
             newTermsField.val(newSelectedTerms.join('\n'));
         }).parent().addClass(config.tags ? 'select2tags' : '');
-    };
+    }
 
     self.initWidget = initWidget;
     self.registerTemplate = registerTemplate;
@@ -122,12 +131,12 @@ window.ftwKeywordWidget = function($) {
     self.init = init;
 
     return self;
-}(jQuery);
+}(jQuery));
 
 window.ftwKeywordWidget.init();
 
 $(window).load(function(){
-  if ($().select2 === undefined) {
+  if ($.fn.select2 === undefined) {
       console.warn('You need to make sure, that select2 jquery plugin is loaded!');
   } else {
     $('.keyword-widget:visible').each(function(index, widget){

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -6,7 +6,19 @@ window.ftwKeywordWidget = function($) {
     var templates = {};
 
     var init = function() {
-      document.dispatchEvent(new Event('ftwKeywordWidgetInit'));
+
+        // Special template to indicate new terms
+        registerTemplate("defaultResultTemplate", function (data) {
+            if (!data.loading && !data._resultId) {
+                return $('<span class="newTag" />')
+                .text(data.text)
+                .append($('<span class="newTagHint" />').text(i18n.label_new));
+            } else {
+                return data.text;
+            }
+        });
+
+        document.dispatchEvent(new Event('ftwKeywordWidgetInit'));
     };
 
     var registerTemplate = function(name, templateFunction) {
@@ -30,8 +42,8 @@ window.ftwKeywordWidget = function($) {
         var config = widget.data("select2config");
         var i18n = config.i18n;
         var ajaxOptions = widget.data("ajaxoptions");
-        var templateSelection = widget.data("templateSelection");
-        var templateResult = widget.data("templateResult");
+        var templateSelection = widget.data("templateselection");
+        var templateResult = widget.data("templateresult");
 
         // Update language from Backend
         config.language = {
@@ -56,16 +68,15 @@ window.ftwKeywordWidget = function($) {
         // Update placholder with translated string
         config.placeholder = i18n.label_placeholder;
 
-        // Special template to indicate new terms
-        config.templateResult = function (data) {
-          if (!data.loading && !data._resultId) {
-            return $('<span class="newTag" />')
-                       .text(data.text)
-                       .append($('<span class="newTagHint" />').text(i18n.label_new));
-          } else {
-            return data.text;
-          }
-        };
+        if (templateResult) {
+            config.templateResult = this.getTemplate(templateResult);
+        } else {
+            config.templateResult = this.getTemplate('defaultResultTemplate');
+        }
+
+        if (templateSelection) {
+            config.templateSelection = this.getTemplate(templateSelection);
+        }
 
         // Add and Update config for remote data
         if (ajaxOptions) {

--- a/ftw/keywordwidget/templates/keyword_input.pt
+++ b/ftw/keywordwidget/templates/keyword_input.pt
@@ -27,6 +27,8 @@
                             multiple view/multiple;
                             data-select2config view/config_json;
                             data-ajaxoptions view/ajax_options_json;
+                            data-templateselection view/template_selection;
+                            data-templateresult view/template_result;
                             size view/size">
 
         <tal:block repeat="item view/items">

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -70,17 +70,22 @@ class KeywordWidget(SelectWidget):
     add_permission = None
     new_terms_as_unicode = None
     async = False
+    template_selection = ''
+    template_result = ''
 
     display_template = ViewPageTemplateFile('templates/keyword_display.pt')
     input_template = ViewPageTemplateFile('templates/keyword_input.pt')
     hidden_template = ViewPageTemplateFile('templates/keyword_hidden.pt')
 
     def __init__(self, request, js_config=None, add_permission=None,
-                 new_terms_as_unicode=False, async=False):
+                 new_terms_as_unicode=False, async=False, template_selection='',
+                 template_result=''):
         self.request = request
         self.js_config = js_config
         self.new_terms_as_unicode = new_terms_as_unicode
         self.async = async
+        self.template_result = template_result
+        self.template_selection = template_selection
 
         self.add_permission = (add_permission or
                                'ftw.keywordwidget: Add new term')


### PR DESCRIPTION
This PR add the possiblity to use own templates for the results or the selected items (https://select2.org/selections)

How does it work?
 
The Keywordwidget will trigger an event called `ftwKeywordWidgetInit` once after it has been initialized.

This is the place, where you need to hook in.

Register an event-listener for this event and register your own template:
```javascript
$(document).on('ftwKeywordWidgetInit', function(e) {
  window.ftwKeywordWidget.registerTemplate('myPurpleTheme', function(data) {
    return $('<span style="background-color:purple" />').text(data.text);
  });
});
```

Now, the template is available for your widgets. Next you need to use your template in a widget:

```python
form.widget('reading', KeywordFieldWidget, template_selection='MyPurpleTheme')
```

Your widget will be registered with your new theme:

<img width="241" alt="bildschirmfoto 2017-11-02 um 16 57 41" src="https://user-images.githubusercontent.com/557005/32336326-49cb0480-bfef-11e7-9def-9d32ed67e4a0.png">

issuer: https://github.com/4teamwork/opengever.core/issues/3493