### PR TITLE
Add context-aware template factory to get access to the widget itself in templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,15 +183,20 @@ You can define your own templates for each plone-widget or you replace the defau
 all your used keywordwidgets.
 
 First of all, you need to create a new templates (take a look at the select2-documentation to
-see what a template is in the select2-context).
+see what a template is in the select2-context). Wrap it into a constructor-function to get access
+to the widget itself (context-aware).
 
 .. code:: javascript
 
-    function myPurpleTemplate(data) {
-        return $('<span style="background-color:purple" />').text(data.text);
+    function myPurpleTemplate(widget) {
+        return function(data) {
+            return $('<span style="background-color:purple" />').text(data.text);
+        }
     }
-    function myBlueTemplate(data) {
-        return $('<span style="background-color:blue" />').text(data.text);
+    function myBlueTemplate(widget) {
+        return function(data) {
+            return $('<span style="background-color:blue" />').text(data.text);
+        }
     }
 
 then you need to register it

--- a/ftw/keywordwidget/resources/js/keywordwidget.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget.js
@@ -8,14 +8,16 @@ window.ftwKeywordWidget = (function($) {
     function init() {
 
         // Special template to indicate new terms
-        registerTemplate("defaultResultTemplate", function (data) {
+        registerTemplate("defaultResultTemplate", function (widget) {
+          return function (data) {
             if (!data.loading && !data._resultId) {
                 return $('<span class="newTag" />')
                 .text(data.text)
-                .append($('<span class="newTagHint" />').text(i18n.label_new));
+                .append($('<span class="newTagHint" />').text(widget.data("select2config").i18n.label_new));
             } else {
                 return data.text;
             }
+          };
         });
 
         $(document).trigger("ftwKeywordWidgetInit");
@@ -33,11 +35,11 @@ window.ftwKeywordWidget = (function($) {
         templates[name] = templateFunction;
     }
 
-    function getTemplate(name, fallback) {
+    function getTemplate(name, fallback, widget) {
         if (templates.hasOwnProperty(name)) {
-            return templates[name];
+            return templates[name](widget);
         } else if (templates.hasOwnProperty(fallback)) {
-            return templates[fallback];
+            return templates[fallback](widget);
         }
         return null;
     }
@@ -81,11 +83,11 @@ window.ftwKeywordWidget = (function($) {
 
         // Register templateResult
         setSelect2Template(config, "templateResult",
-                           this.getTemplate(templateResult, "defaultResultTemplate"));
+                           this.getTemplate(templateResult, "defaultResultTemplate", widget));
 
         // Register templateSelection
         setSelect2Template(config, "templateSelection",
-                           this.getTemplate(templateSelection, "defaultSelectionTemplate"));
+                           this.getTemplate(templateSelection, "defaultSelectionTemplate", widget));
 
         // Add and Update config for remote data
         if (ajaxOptions) {


### PR DESCRIPTION
To get access to the widget-config for i18n-strings, we need to add a template factory with the widget as a parameter.

This PR will fix an issue with the default result template.