### PR TITLE
Fix an issue where the term-lookup will fail after the form-validation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an issue where the term-lookup will fail after the form-validation.
+  https://github.com/4teamwork/ftw.keywordwidget/issues/27
+  [elioschmutz]
 
 
 1.4.1 (2017-11-15)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -313,7 +313,7 @@ class KeywordWidget(SelectWidget):
                  'selected': selected})
 
         if self.async:
-            terms = [self.terms.getTermByToken(v) for v in self.value]
+            terms = [self.terms.getTermByToken(v) for v in self.value if v]
         else:
             terms = self.terms
 


### PR DESCRIPTION
This PR fixes the term-lookup issue. See #27 for more information about the issue itself.

Unfortunately I couldn't reproduce this issue with tests. See the separate branch (https://github.com/4teamwork/ftw.keywordwidget/compare/es-27-fix-term-lookup-with-failing-tests?expand=1).

But I can reproduce it through the web.

Closes #27 