### PR TITLE
Fix an error where it was no longer possible to add tags after another async widget have been used.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an error where it was no longer possible to add tags after another async widget have been used. [elioschmutz]
 
 
 2.0.0 (2019-04-18)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -149,13 +149,14 @@ class KeywordWidget(SelectWidget):
         super(KeywordWidget, self).update()
 
         self.update_multivalued_property()
-        self.update_js_config()
 
         if isinstance(self.choice_field, ChoicePlus):
             api.portal.getRequest().allow_new = api.user.has_permission(
                 self.add_permission,
                 obj=self.context,
                 )
+
+        self.update_js_config()
 
     def update_js_config(self):
         # Sane default config


### PR DESCRIPTION
This PR fixes an issue where it was no longer possible to add tags on a keywordwidget, after using another async keywordwidget.

The main-problem is, that using an async widget will trigger all the widgets `update` method. This request seems to be correct, but in some cases, the user will be `Anonymous`.

The following check https://github.com/4teamwork/ftw.keywordwidget/blob/master/ftw/keywordwidget/widget.py#L156 will fail for the `ChoicePlus` and the `allow_new` attribute will be set to `False`. This value is persisted for the next requests.

So if we reload the page, the `allow_new` value is still `False`. Because the `js-config` will be updated before this security-check, we'll loose the permission to add new tags for this second request. Reloading once again will fix it again.

This PR just updates the `js-config` after the security-check.

Unfortunately I couldn't find out why the user is `Anonymous` in some cases. I was digging in the `PluggableAuthService` without any solution. Everything seems to be ok. I would need more time to debug if it's desired. But I think, it is not necessary.

Writing a test is not really possible because I don't know when I'll get the Anonymous user.

Before:

![screen1](https://user-images.githubusercontent.com/557005/33721769-3f6d7452-db68-11e7-8a92-0ec19f7b50e5.gif)

After:

![screen2](https://user-images.githubusercontent.com/557005/33721807-5fac6e44-db68-11e7-8e1e-7ed87972194c.gif)

