### PR TITLE
Fix french translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix french translations. [phgross]
 
 1.5.0 (2017-12-14)
 ------------------

--- a/ftw/keywordwidget/locales/fr/LC_MESSAGES/ftw.keywordwidget.po
+++ b/ftw/keywordwidget/locales/fr/LC_MESSAGES/ftw.keywordwidget.po
@@ -40,7 +40,7 @@ msgstr "Aucun résultat trouvé"
 
 #: ./ftw/keywordwidget/widget.py:53
 msgid "Please enter "
-msgstr "Veuillez saisir"
+msgstr "Veuillez saisir "
 
 #: ./ftw/keywordwidget/widget.py:51
 msgid "Searching..."


### PR DESCRIPTION
There was a missing space after `Veuillez saisir` in the french translation.

![image](https://user-images.githubusercontent.com/485755/39232134-94c4cf4c-486c-11e8-8dea-eddb554e8b5b.png)
