### PR TITLE
Remove improper 'parent of parent' field validations from the ChoicePlus field

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove improper parent of parent validations from ChoicePlus.
+  [Rotonen]
 
 
 1.5.0 (2017-12-14)

--- a/ftw/keywordwidget/field.py
+++ b/ftw/keywordwidget/field.py
@@ -1,6 +1,7 @@
 from plone import api
 from zope.interface import implementer
 from zope.schema import Choice
+from zope.schema._bootstrapinterfaces import WrongType
 from zope.schema.interfaces import ConstraintNotSatisfied
 from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import IFromUnicode
@@ -19,7 +20,12 @@ class ChoicePlus(Choice):
         if self._init_field:
             return
 
-        super(Choice, self)._validate(value)
+        if self._type is not None and not isinstance(value, self._type):
+            raise WrongType(value, self._type, self.__name__)
+
+        if not self.constraint(value):
+            raise ConstraintNotSatisfied(value)
+
         vocabulary = self.vocabulary
         if vocabulary is None:
             vr = getVocabularyRegistry()


### PR DESCRIPTION
Seems what we want to do here is the validation from bootstrapfields `Field`.

https://github.com/zopefoundation/zope.schema/blob/4.2.2/src/zope/schema/_field.py#L376-L389
https://github.com/zopefoundation/zope.schema/blob/4.2.2/src/zope/schema/_bootstrapfields.py#L207-L212

Nothing failed in either `ftw.keywordwidget` or `opengever.core` when just removing the check, but I'm more comfortable just using copying the grandparent checks in manually here.

Closes https://github.com/4teamwork/ftw.keywordwidget/issues/32