### PR TITLE
Allow adding new terms in async mode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Allow to use sources also not in async mode. [njohner]
 - Allow adding new terms in async mode. [njohner]
 - Fix an error where it was no longer possible to add tags after another async widget have been used. [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Allow adding new terms in async mode. [njohner]
 - Fix an error where it was no longer possible to add tags after another async widget have been used. [elioschmutz]
 
 

--- a/ftw/keywordwidget/behavior.py
+++ b/ftw/keywordwidget/behavior.py
@@ -1,11 +1,12 @@
 from ftw.keywordwidget.field import ChoicePlus
+from ftw.keywordwidget.vocabularies import KeywordSearchableAndAddableSourceBinder
 from ftw.keywordwidget.vocabularies import KeywordSearchableSourceBinder
 from ftw.keywordwidget.widget import KeywordFieldWidget
-from Products.CMFPlone import PloneMessageFactory as _PMF
 from plone.app.dexterity.behaviors.metadata import MetadataBase
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
+from Products.CMFPlone import PloneMessageFactory as _PMF
 from z3c.form.interfaces import IEditForm, IAddForm
 from zope import schema
 from zope.interface import alsoProvides
@@ -103,6 +104,17 @@ class IKeywordUseCases(model.Schema):
         value_type=schema.Choice(
             title=u"Multiple",
             source=KeywordSearchableSourceBinder(),
+            ),
+        required=False,
+        missing_value=(),
+    )
+
+    directives.widget('async_addable', KeywordFieldWidget, async=True)
+    async_addable = schema.Tuple(
+        title=u'async_addable',
+        value_type=ChoicePlus(
+            title=u"Multiple",
+            source=KeywordSearchableAndAddableSourceBinder(),
             ),
         required=False,
         missing_value=(),

--- a/ftw/keywordwidget/tests/test_different_cases.py
+++ b/ftw/keywordwidget/tests/test_different_cases.py
@@ -253,3 +253,165 @@ class TestAsyncOption(FunctionalTestCase):
         form.update()
         widget = form.widgets['IKeywordUseCases.async']
         return SearchSource(widget, widget.request)()
+
+
+class TestAsyncAddableOption(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestAsyncAddableOption, self).setUp()
+        self.grant('Manager')
+        additional_behaviors = [
+            'ftw.keywordwidget.behavior.IKeywordCategorization',
+            'ftw.keywordwidget.behavior.IKeywordUseCases',
+        ]
+        self.setup_fti(additional_behaviors=additional_behaviors)
+        transaction.commit()
+
+    @browsing
+    def test_async_render_only_selected_items(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib')
+                         .having(async_addable=('abc', 'zzzzzz', 'lorem')))
+
+        browser.login().visit(content, view='edit')
+        field = browser.find_field_by_text('async_addable')
+        self.assertListEqual(list(field.value), field.options_values)
+
+    @browsing
+    def test_async_option_is_selectable_but_not_rendered(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib'))
+
+        browser.login().visit(content, view='edit')
+        field = browser.find_field_by_text('async_addable')
+        self.assertFalse(tuple(field.value), 'Expect no selectable options')
+
+        form = browser.find_form_by_field('async_addable')
+        form.find_widget('async_addable').fill(['foo', 'bar'])
+        form.submit()
+
+        self.assertSequenceEqual(['foo', 'bar'], content.async_addable)
+
+    @browsing
+    def test_async_option_terms_not_in_source_are_ignored(self, browser):
+        create(Builder('sample content')
+               .titled(u'A content')
+               .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                 'zzzzzz', 'lorem', 'ipsum')))
+
+        content = create(Builder('sample content')
+                         .titled(u'Use async lib'))
+
+        browser.login().visit(content, view='edit')
+
+        form = browser.find_form_by_field('async_addable')
+        form.find_widget('async_addable').fill(['New', 'New2'])
+        form.submit()
+
+        self.assertFalse(content.async_addable, 'Expect nothing in field async')
+
+    @browsing
+    def test_can_add_terms_in_async_mode(self, browser):
+        content = create(Builder('sample content').titled(u'A content'))
+        browser.login().visit(content, view='edit')
+
+        tags = browser.find_field_by_text(u'async_addable')
+        form = browser.find_form_by_field('async_addable')
+        new = browser.css('#' + tags.attrib['id'] + '_new').first
+        new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
+        form.submit()
+
+        self.assertItemsEqual(('New Item 2', 'NewItem1', 'N\xc3\xb6i 3'),
+                              content.async_addable)
+
+    def test_async_option_only_works_with_IQuerySource(self):
+
+        @implementer(IContextSourceBinder)
+        class DummySource(object):
+            def __call__(self, context):
+                return SimpleVocabulary([])
+
+        content = create(Builder('sample content')
+                         .titled(u'A content')
+                         .having(subjects=('foo', 'bar', 'baz', 'abc')))
+
+        edit_form = content.restrictedTraverse('@@edit').form_instance
+        edit_form.update()
+        new_field = Choice(title=u'dummy', source=DummySource())
+        edit_form.fields['IKeywordUseCases.async_addable'].field = new_field
+
+        with self.assertRaises(TypeError):
+            edit_form.update()
+
+    def test_search_endpoint(self):
+        content = create(Builder('sample content')
+                         .titled(u'A content')
+                         .having(subjects=('foo', 'bar', 'baz', 'abc',
+                                           'zzzzzz', 'lorem', 'ipsum')))
+
+        self.portal.REQUEST.set('q', 'ba')
+        result = json.loads(self._get_search_view(content))
+
+        self.assertTrue(isinstance(result, dict))
+        self.assertIn('total_count', result)
+        self.assertEquals(result['total_count'], 2)
+
+        self.assertIn('page', result)
+        self.assertEquals(result['page'], 1)
+
+        self.assertIn('results', result)
+        self.assertEquals([{'_resultId': u'bar',
+                            'id': u'bar',
+                            'text': u'bar'},
+                           {'_resultId': u'baz',
+                            'id': u'baz',
+                            'text': u'baz'}, ],
+                          result['results'])
+
+        self.portal.REQUEST.set('q', 'dummy')
+        result = json.loads(self._get_search_view(content))
+        self.assertEquals([], result['results'])
+
+    def test_search_endpoint_batch_result(self):
+        content = create(Builder('sample content')
+                         .titled(u'A content')
+                         .having(subjects=map(str, range(1, 100))))
+
+        self.portal.REQUEST.set('q', '1')
+        self.portal.REQUEST.set('pagesize', '5')
+        self.portal.REQUEST.set('page', '1')
+        result = json.loads(self._get_search_view(content))
+
+        self.assertEquals(5, len(result['results']))
+        self.assertEquals(19, result['total_count'])
+        self.assertEquals([u'1', u'10', u'11', u'12', u'13'],
+                          self._get_values(result['results']))
+
+        self.portal.REQUEST.set('q', '1')
+        self.portal.REQUEST.set('pagesize', '5')
+        self.portal.REQUEST.set('page', '3')
+        result = json.loads(self._get_search_view(content))
+
+        self.assertEquals(5, len(result['results']))
+        self.assertEquals(19, result['total_count'])
+        self.assertEquals([u'19', u'21', u'31', u'41', u'51'],
+                          self._get_values(result['results']))
+
+    def _get_values(self, items):
+        return map(lambda item: item['id'], items)
+
+    def _get_search_view(self, context):
+        form = context.unrestrictedTraverse('@@edit').form_instance
+        form.update()
+        widget = form.widgets['IKeywordUseCases.async_addable']
+        return SearchSource(widget, widget.request)()

--- a/ftw/keywordwidget/utils.py
+++ b/ftw/keywordwidget/utils.py
@@ -1,4 +1,12 @@
+from binascii import b2a_qp
+
+
 def safe_utf8(text):
     if isinstance(text, unicode):
         text = text.encode('utf8')
     return text
+
+
+def as_keyword_token(value):
+    value = safe_utf8(value)
+    return b2a_qp(value)

--- a/ftw/keywordwidget/vocabularies.py
+++ b/ftw/keywordwidget/vocabularies.py
@@ -91,6 +91,9 @@ class KeywordWidgetAddableSourceWrapper(object):
             return getattr(self, attr)
         return getattr(self._source, attr)
 
+    def __iter__(self):
+        return iter(self._source)
+
 
 @implementer(IQuerySource)
 class KeywordSearchableSource(object):

--- a/ftw/keywordwidget/vocabularies.py
+++ b/ftw/keywordwidget/vocabularies.py
@@ -1,5 +1,6 @@
 from binascii import b2a_qp
 from ftw.keywordwidget.utils import safe_utf8
+from ftw.keywordwidget.utils import as_keyword_token
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from z3c.formwidget.query.interfaces import IQuerySource
@@ -102,7 +103,7 @@ class KeywordSearchableSource(object):
         catalog = getToolByName(context, 'portal_catalog')
         self.keywords = catalog.uniqueValuesFor('Subject')
         self.vocab = SimpleVocabulary.fromItems(
-            [(x, x) for x in self.keywords])
+            [(as_keyword_token(x), x) for x in self.keywords])
 
     def __contains__(self, term):
         return self.vocab.__contains__(term)

--- a/ftw/keywordwidget/vocabularies.py
+++ b/ftw/keywordwidget/vocabularies.py
@@ -1,6 +1,7 @@
 from binascii import b2a_qp
-from ftw.keywordwidget.utils import safe_utf8
 from ftw.keywordwidget.utils import as_keyword_token
+from ftw.keywordwidget.utils import safe_utf8
+from itertools import chain
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from z3c.formwidget.query.interfaces import IQuerySource
@@ -92,7 +93,10 @@ class KeywordWidgetAddableSourceWrapper(object):
         return getattr(self._source, attr)
 
     def __iter__(self):
-        return iter(self._source)
+        return chain(self._source, self.instance_vocabulary)
+
+    def __contains__(self, value):
+        return value in chain(self._source, self.instance_vocabulary)
 
 
 @implementer(IQuerySource)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -266,7 +266,7 @@ class KeywordWidget(SelectWidget):
             # It's only possible to add new terms in async mode if the source
             # implements IKeywordWidgetAddableSource
             return self.terms
-        elif self.async and IKeywordWidgetAddableSource.providedBy(vocabulary):
+        elif IKeywordWidgetAddableSource.providedBy(vocabulary):
             simple_vocabulary = self.terms.terms.instance_vocabulary
         else:
             simple_vocabulary = self.terms.terms
@@ -290,7 +290,7 @@ class KeywordWidget(SelectWidget):
                 terms.append(
                     SimpleTerm(new_value, new_token, safe_unicode(new_value)))
 
-        if self.async and IKeywordWidgetAddableSource.providedBy(vocabulary):
+        if IKeywordWidgetAddableSource.providedBy(vocabulary):
             self.terms.terms.instance_vocabulary = SimpleVocabulary(terms)
         else:
             self.terms.terms = SimpleVocabulary(terms)

--- a/ftw/keywordwidget/widget.py
+++ b/ftw/keywordwidget/widget.py
@@ -1,6 +1,6 @@
-from binascii import b2a_qp
 from ftw.keywordwidget import _
 from ftw.keywordwidget.field import ChoicePlus
+from ftw.keywordwidget.utils import as_keyword_token
 from ftw.keywordwidget.utils import safe_utf8
 from ftw.keywordwidget.vocabularies import IKeywordWidgetAddableSource
 from plone import api
@@ -32,12 +32,6 @@ def is_list_type_field(field):
         return True
 
     return False
-
-
-def as_keyword_token(value):
-    if isinstance(value, unicode):
-        value = value.encode('utf-8')
-    return b2a_qp(value)
 
 
 class IKeywordWidget(ISelectWidget):


### PR DESCRIPTION
Adding new terms in the `KeywordWidget` in `async` mode was not allowed. All that is needed to add this feature is that newly added terms pass form validation so that the new values get set on the field (in the case of keywords, this will then update the `subject` index when the object is reindexed).
Because the `KeywordSearchableSource` uses a `SimpleVocabulary` in its implementation (`self.vocab`), we could simply have added the new terms in there, but this would have been a specific solution for the `KeywordSearchableSource`. Instead, we write a wrapper class `KeywordWidgetAddableSourceWrapper` that should allow to make any source addable in async mode. `KeywordWidgetAddableSourceWrapper` basically adds a `SimpleVocabulary` to the source instance to track newly added terms (the wrapper actually has an `instance_vocabulary` as attribute, overwrites `getTermByToken` to also check whether a given term is in `instance_vocabulary` and delegates everything else to the source).

This is for https://github.com/4teamwork/opengever.core/issues/5733