### PR TITLE
Fix race condition: Explicitly flush collective.indexing queue before building vocabularies

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Explicitly flush collective.indexing queue before building vocabularies
+  to address some race conditions where catalog contents aren't up-to-date. [lgraf]
 
 
 2.1.1 (2019-10-17)

--- a/ftw/keywordwidget/compat.py
+++ b/ftw/keywordwidget/compat.py
@@ -1,0 +1,15 @@
+import pkg_resources
+
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
+
+
+if IS_PLONE_5:
+    from Products.CMFCore.indexing import processQueue
+else:
+    # optional collective.indexing support
+    try:
+        from collective.indexing.queue import processQueue
+    except ImportError:
+        def processQueue():
+            pass

--- a/ftw/keywordwidget/vocabularies.py
+++ b/ftw/keywordwidget/vocabularies.py
@@ -1,4 +1,5 @@
 from binascii import b2a_qp
+from ftw.keywordwidget.compat import processQueue
 from ftw.keywordwidget.utils import as_keyword_token
 from ftw.keywordwidget.utils import safe_utf8
 from itertools import chain
@@ -32,6 +33,11 @@ class UnicodeKeywordsVocabulary(object):
 
     def __call__(self, context):
         site = getSite()
+
+        # XXX: Explicitly flush collective.indexing queue to make sure we
+        # work with up-to-date results.
+        processQueue()
+
         self.catalog = getToolByName(site, "portal_catalog", None)
         if self.catalog is None:
             return SimpleVocabulary([])
@@ -107,6 +113,11 @@ class KeywordSearchableSource(object):
 
     def __init__(self, context):
         self.context = context
+
+        # XXX: Explicitly flush collective.indexing queue to make sure we
+        # work with up-to-date results.
+        processQueue()
+
         catalog = getToolByName(context, 'portal_catalog')
         self.keywords = catalog.uniqueValuesFor('Subject')
         self.vocab = SimpleVocabulary(

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'plone.app.contenttypes',
     'plone.app.testing',
     'plone.testing',
+    'unittest2',
 ]
 
 extras_require = {


### PR DESCRIPTION
When building catalog based vocabularies, we've had some race conditions where the catalog contents weren't up-to-date, because `collective.indexing` didn't process the required `reindexObject` calls yet.

This is because `collective.indexing` only patches `ZCatalog.searchResults()`, but not lower-level methods like `uniqueValuesFor()` or direct access to indexes. Therefore it also doesn't do the force-flush it usually does before querying the catalog. That way, you can, depending of execution order of events, end up with situations where newly added keywords have been "indexed", but the indexing hasn't yet been processed when the vocabularies are built.

We therefore explicitly flush the `collective.indexing` queue before accessing the catalog in these vocabularies.  