### PR TITLE
Remove unittest2 dependency.

### DIFF
--- a/ftw/keywordwidget/tests/__init__.py
+++ b/ftw/keywordwidget/tests/__init__.py
@@ -6,7 +6,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.dexterity.content import Container
 from plone.dexterity.fti import DexterityFTI
 from plone.supermodel import model
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface import implements
 from zope.interface import Interface
 import ftw.keywordwidget.tests.widget

--- a/ftw/keywordwidget/tests/test_uninstall.py
+++ b/ftw/keywordwidget/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
 from ftw.testing.genericsetup import apply_generic_setup_layer
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ tests_require = [
     'plone.app.contenttypes',
     'plone.app.testing',
     'plone.testing',
-    'unittest2',
 ]
 
 extras_require = {


### PR DESCRIPTION
We are no longer using `unittest2`, but `unittest`.