### PR TITLE
select2 widget not initialized on plone5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix select2 widget not being reinitialized when switching between edit form tabs (resolves #42) [djowett-ftw]
 
 
 2.1.2 (2019-11-12)
@@ -33,8 +33,7 @@ Changelog
 2.0.0 (2019-04-18)
 ------------------
 
-- Add support for Plone 5.1.x. [mbaechtold]
-- Fit newer version of select2 into keywordwidget resources to prevent conflict
+- Add support for Plone 5.1.x. [mbaechtold] - Fit newer version of select2 into keywordwidget resources to prevent conflict
   with an older vers. of select2 required by plone. [mathias.leimgruber, busykoala]
 
 

--- a/ftw/keywordwidget/resources/js/keywordwidget_5.x.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget_5.x.js
@@ -6446,7 +6446,7 @@ $(window).load(function(){
 
 // select2 has problems getting the correct width of the placeholder element if the content is hidden and select2 gets initialized.
 // See https://github.com/select2/select2/issues/291
-$(document).on("click", "form.enableFormTabbing > nav.autotoc-nav a, select.formTabs a, ul.formTabs a", function (e, index) {
+$("form.enableFormTabbing > nav.autotoc-nav a, select.formTabs a, ul.formTabs a").on("click", function (e, index) {
   $('.keyword-widget:visible').each(function(index, widget){
     window.ftwKeywordWidget.initWidget($(widget));
   });

--- a/ftw/keywordwidget/resources/js/keywordwidget_5.x.js
+++ b/ftw/keywordwidget/resources/js/keywordwidget_5.x.js
@@ -6434,8 +6434,9 @@ S2.define('jquery.select2',[
 window.ftwKeywordWidget.init();
 
 $(window).load(function(){
-  if ($.fn.select2 === undefined) {
-      console.warn('You need to make sure, that select2 jquery plugin is loaded!');
+  if ($.fn.hackS2 === undefined) {
+      // This should not happen while select2 has been vendored within this module
+      console.warn('You need to make sure, that the select2 jquery plugin is loaded!');
   } else {
     $('.keyword-widget:visible').each(function(index, widget){
       window.ftwKeywordWidget.initWidget($(widget));
@@ -6443,9 +6444,9 @@ $(window).load(function(){
   }
 });
 
-// select2 has issues to get right width of the placeholder element if the content is hidden and select2 gets initialized.
+// select2 has problems getting the correct width of the placeholder element if the content is hidden and select2 gets initialized.
 // See https://github.com/select2/select2/issues/291
-$(document).on("click", "select.formTabs a, ul.formTabs a", function (e, index) {
+$(document).on("click", "form.enableFormTabbing > nav.autotoc-nav a, select.formTabs a, ul.formTabs a", function (e, index) {
   $('.keyword-widget:visible').each(function(index, widget){
     window.ftwKeywordWidget.initWidget($(widget));
   });


### PR DESCRIPTION
resolves #42 

BUT #46 is not resolved, so this shouldn't be released without a fix for that ticket